### PR TITLE
Enable orgmode which adds orgs to the team list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.2
+
+* Adds `orgmode` parameter which will append the org name to the team list as `org:${orgname}`.
+
 ## 1.0.1
 
 * Added pagination to the team call so if you're on more than 100 teams it'll pick them up.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # verdaccio-github-auth
 
 ![Travis Build Status](https://travis-ci.org/cthos/verdaccio-github-auth.svg?branch=master)
-
+`
 This is a simple Github Authentication plugin for verdaccio. 
 
 ## Config
@@ -11,21 +11,21 @@ github-auth:
      org: cthos # OPTIONAL: Filter the user's teams to this organization
      mode: token # token or basic. Token expects an auth token as the password. Basic is raw username/password for github. DEFAULT: token
      cachettl: 5 # OPTIONAL: How long to cache the user's teams in minutes. DEFAULT: 5
+     orgmode: true # OPTIONAL: allow orgs to be placed in the `access` stanza.
 
 
     '**':
     # Access is determined by team permissions, but github username is also valid.
-    access: team1 team2 awesomteam cthos
+      access: team1 team2 awesomteam cthos
+
+    '@volcano/*':
+      access: org:volcano # allows access to everyone in the volcano org
 ```
 
 ## Gotchas
 
 * You cannot use `basic` with 2FA as far as I'm aware - you'd need to use the token type.
 * The personal access token needs `read:org` and `read:user`. 
-
-## Planned Enhancements
-
-* (Optionally) Allow the access permissions to be based off of org membership, not just team access.
 
 ## Current Limitations
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # verdaccio-github-auth
 
 ![Travis Build Status](https://travis-ci.org/cthos/verdaccio-github-auth.svg?branch=master)
-`
+
 This is a simple Github Authentication plugin for verdaccio. 
 
 ## Config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verdaccio-github-auth",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Verdaccio Github Authentication Plugin",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -32,6 +32,24 @@ describe('Verdaccio Github Auth', () => {
     });
   });
 
+  it('should not return orgs if orgmode is off.', async () => {
+    client = VerdaccioGithubAuthWrapper({org: null, orgmode: false}, {});
+
+    client.authenticate(process.env.GITHUB_USERNAME, process.env.GITHUB_TOKEN, (a, teams) => {
+      expect(teams).to.not.be.empty;
+      expect(teams).to.not.contain('org:volcano');
+    });
+  });
+
+  it('should return orgs if orgmode is on.', async () => {
+    client = VerdaccioGithubAuthWrapper({org: null, orgmode: true}, {});
+
+    client.authenticate(process.env.GITHUB_USERNAME, process.env.GITHUB_TOKEN, (a, teams) => {
+      expect(teams).to.not.be.empty;
+      expect(teams).to.contain('org:volcano');
+    });
+  });
+
   it('should not allow bad authentication', (done) => {
     client.adduser(process.env.GITHUB_USERNAME, 'thisisnotthetokenyouareafter', (err, good) => {
       expect(err).to.be.a.instanceof(Error);


### PR DESCRIPTION
This adds an option which will append orgs to the user's team list, in the format `org:${orgname}`.

Defaults to false.